### PR TITLE
Pin Codly citation URLs to the cited 1.3.0 version

### DIFF
--- a/references.bib
+++ b/references.bib
@@ -10,7 +10,7 @@
     author          = {Dherse},
     title           = {Codly 1.3.0 package},
     date            = {2025},
-    url             = {https://typst.app/universe/package/codly/},
+    url             = {https://typst.app/universe/package/codly/1.3.0/},
     urldate         = {2025-11-11},
 }
 

--- a/references.bib
+++ b/references.bib
@@ -18,7 +18,7 @@
     author          = {Dherse},
     title           = {Codly 1.3.0 documentation},
     date            = {2025},
-    url             = {https://raw.githubusercontent.com/Dherse/codly/main/docs.pdf},
+    url             = {https://raw.githubusercontent.com/Dherse/codly/v1.3.0/docs.pdf},
     urldate         = {2025-11-11},
 }
 


### PR DESCRIPTION
Both Codly entries in references.bib cite version 1.3.0, but their URLs pointed at floating resources: docs.pdf on the main branch of Dherse/codly and the unversioned Typst Universe package page. This PR pins both URLs to the cited version, using the v1.3.0 tag for the docs link and the versioned 1.3.0 page for the package link. The copy of docs.pdf on main has already drifted from the 1.3.0 release (Codly 1.3.1 is out on GitHub), so the pinned links keep the citations accurate.