### PR TITLE
Auto-generate the required AI-use statement per author

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,34 @@ you may need to change the template code
 or apply a new [set / show rule](https://typst.app/docs/reference/styling/)
 in your document(s).
 
+## AI-use statement
+
+The university requires every diploma thesis to include a signed
+**statement on the use of artificial intelligence**
+(_Oświadczenie studenta dotyczące wykorzystania AI_ /
+_Statement of student — Use of AI_).
+This template adds it for you automatically.
+
+One statement page is generated **per author** in `authors`,
+inserted right after the abstract and before the table of contents
+(with one blank page in front of the first statement).
+Every field is filled in from arguments you already provide:
+
+- the **name** and **album number** come from each `authors` entry
+  (the part before `---` is the name, the part after it is the album number);
+- the **field of study** comes from `field-of-study` / `field-of-study-pl`
+  (see the argument reference below);
+- the **city and date** are inserted automatically
+  (the university's city and today's date);
+- the **signature line is left blank** for a handwritten signature.
+
+The statement is rendered in a **single language** — your document's
+`language`.
+An English thesis therefore gets the English statement only,
+and a Polish thesis the Polish one
+(unlike the title page and abstract,
+which are produced in both languages for English theses).
+
 ## Documentation for `apply-pjatk-template()` function arguments
 
 > [!NOTE]
@@ -163,6 +191,11 @@ for Enlgish theses.
 
   Name of your specialization.
   You should know it.
+- `field-of-study: "Computer Science"` (🇬🇧)
+
+  Your field of study (Polish _kierunek_),
+  used to fill in the [AI-use statement](#ai-use-statement)
+  when the thesis is written in English (`language: "en"`).
 - `authors: ("Your Name --- s#####",)` (🇬🇧+🇵🇱)
 
   Array of authors' full names and index numbers.
@@ -231,6 +264,14 @@ for Enlgish theses.
 - `specialization-pl: "Nazwa specjalizacji"` (🇬🇧)
 
   Translation of your specialization.
+- `field-of-study-pl: "Informatyka"` (🇵🇱)
+
+  Polish name of your field of study,
+  shown on the [AI-use statement](#ai-use-statement)
+  of a **Polish** thesis (`language: "pl"`).
+  Unlike the other `-pl` arguments,
+  this one is _not_ a translation used on the English thesis' Polish pages
+  — it is the value used when the whole statement is in Polish.
 - `title-pl: "Twój starannie dobrany i ekspresywny tytuł pracy dyplomowej"` (🇬🇧)
 
   Translation of your title.

--- a/pjatk-template.typ
+++ b/pjatk-template.typ
@@ -12,6 +12,37 @@
     "list-of-tables": ("pl": "Spis Tabel", "en": "List of Tables"),
 )
 
+#let aiStatementStrings = (
+    "pl": (
+        "title": "OŚWIADCZENIE STUDENTA DOTYCZĄCE WYKORZYSTANIA SZTUCZNEJ INTELIGENCJI (AI)",
+        "name-prefix": "Ja, niżej podpisany/a:",
+        "field-prefix": "student/ka kierunku:",
+        "album-prefix": "numer albumu studenta:",
+        "paragraphs": (
+            "Oświadczam, że zapoznałem/am się z treścią Zarządzenia Rektora Polsko-Japońskiej Akademii Technik Komputerowych z dnia 1 kwietnia 2026 r. oraz z \"Wytycznymi dotyczącymi wykorzystywania sztucznej inteligencji w procesie dydaktycznym PJATK\", stanowiącymi załącznik do ww. zarządzenia.",
+            "Oświadczam, że ewentualne wykorzystanie narzędzi sztucznej inteligencji (AI) w niniejszej pracy miało charakter wyłącznie pomocniczy i nie stanowiło zastępstwa dla mojej samodzielnej pracy.",
+            "Oświadczam, że treść pracy stanowi moje własne, samodzielne opracowanie oraz ponoszę pełną odpowiedzialność za jej zawartość, niezależnie od wykorzystania narzędzi AI.",
+            "Oświadczam, że nie wykorzystywałem/am narzędzi AI do generowania treści stanowiących zasadniczą część pracy, w szczególności analiz, wniosków, interpretacji ani części podlegających ocenie jako przejaw twórczości własnej.",
+            "W przypadku korzystania z narzędzi AI sporządziłem/am Raport użycia AI zgodnie z obowiązującymi Wytycznymi i dołączyłem/am go do pracy.",
+        ),
+        "signature-label": "(czytelny podpis studenta/studentki)",
+    ),
+    "en": (
+        "title": "STUDENT'S STATEMENT REGARDING THE USE OF ARTIFICIAL INTELLIGENCE (AI)",
+        "name-prefix": "I, undersigned:",
+        "field-prefix": "Student:",
+        "album-prefix": "Student's album number:",
+        "paragraphs": (
+            "I hereby declare that I have read the content of the Order of the Rector of the Polish-Japanese Academy of Information Technology of 1 April 2026 and the \"Guidelines on the use of artificial intelligence in the teaching process of PJATK\", which are attached to the above-mentioned order.",
+            "I declare that the possible use of artificial intelligence (AI) tools in this work was only auxiliary and did not constitute a substitute for my independent work.",
+            "I declare that the content of the work is my own research and I am fully responsible for its content, regardless of the use of AI tools.",
+            "I declare that I have not used AI tools to generate content that constitutes an essential part of the work, in particular analyses, conclusions, interpretations or parts that are subject to evaluation as a manifestation of my own work.",
+            "In the case of using AI tools, I have prepared an AI Usage Report in accordance with the applicable Guidelines and attached it to the work.",
+        ),
+        "signature-label": "(legible signature of the student)",
+    ),
+)
+
 #let placeholder-abstract = [
     The abstract should be between 400 and 1500 characters, including spaces.
     *Thesis written in English must also include abstract and keywords translation to Polish*.
@@ -28,6 +59,8 @@
     #sym.dot.op Threat #sym.dot.op them #sym.dot.op as #sym.dot.op tags #sym.dot.op Your #sym.dot.op thesis
     #sym.dot.op must #sym.dot.op be #sym.dot.op searchable #sym.dot.op using #sym.dot.op them #sym.dot.op
     Separate them by using the `#sym.dot.op` syntax.]
+
+#let mk(t) = eval(mode: "markup", t)
 
 #let titlepage(
     language,
@@ -55,7 +88,7 @@
 
            #v(1cm)
 
-           #eval(mode: "markup", authors.map(s => s.replace("#", "\#") + "\\").join("\n"))
+           #mk(authors.map(s => s.replace("#", "\#") + "\\").join("\n"))
 
            #v(1cm)
 
@@ -97,12 +130,55 @@
     keywords
 }
 
+#let aiStatement(language, name, album, field, placeDate) = {
+    let s = aiStatementStrings.at(language)
+
+    align(right)[
+        #set par(justify: false)
+        #placeDate
+    ]
+
+    v(2.2cm)
+
+    align(center)[
+        #set par(justify: false)
+        #strong(text(size: 1.1em, hyphenate: false)[#mk(s.at("title"))])
+    ]
+
+    v(1.6cm)
+
+    let fieldLine(prefix, value) = block(below: 0.55em)[
+        #mk(prefix) #mk(value.replace("#", "\#"))
+    ]
+
+    {
+        set par(justify: false)
+        fieldLine(s.at("name-prefix"), name)
+        fieldLine(s.at("field-prefix"), field)
+        fieldLine(s.at("album-prefix"), album)
+    }
+
+    v(1em)
+
+    for p in s.at("paragraphs") {
+        block(below: 0.65em)[#mk(p)]
+    }
+
+    v(1.8cm)
+    align(right)[
+        #set par(justify: false)
+        #box(width: 6.5cm, repeat(gap: 2pt)[.]) \
+        #mk(s.at("signature-label"))
+    ]
+}
+
 #let apply-pjatk-template(
     body,
     language: "en",
     faculty: "Faculty of Computer Science",
     department: "Name of your Specialization's Department",
     specialization: "Name of your Specialization",
+    field-of-study: "Computer Science",
     authors: ("Your Name --- s#####",),
     title: "Your Carefully Selected and Expressive Thesis Title",
     supervisor: "Supervisor's Name",
@@ -115,6 +191,7 @@
     faculty-pl: "Wydział Informatyki",
     department-pl: "Nazwa katedry",
     specialization-pl: "Nazwa specjalizacji",
+    field-of-study-pl: "Informatyka",
     title-pl: "Twój starannie dobrany i ekspresywny tytuł pracy dyplomowej",
     abstract-pl: "Tłumaczenie streszczenia.",
     keywords-pl: "Tłumaczenie słów kluczowych.",
@@ -253,6 +330,23 @@
             set text(lang: "pl")
             abstractAndKeywords("pl", abstract-pl, keywords-pl)
             set text(lang: "en")
+        }
+    }
+
+    context {
+        let stmtLang = text.lang
+        let fieldValue = if stmtLang == "pl" { field-of-study-pl } else { field-of-study }
+        let dateLocale = if stmtLang == "pl" { "pl" } else { "en-GB" }
+        let placeDate = [#commonPhrases.at("city").at(stmtLang), #icu.fmt(datetime.today(), date-fields: "YMD", locale: dateLocale, length: "long")#if stmtLang == "pl" [ r.]]
+
+        pagebreak()
+        pagebreak()
+        for (i, author) in authors.enumerate() {
+            if i > 0 { pagebreak() }
+            let parts = author.split("---")
+            let name = parts.at(0).trim()
+            let album = if parts.len() > 1 { parts.at(1).trim() } else { "" }
+            aiStatement(stmtLang, name, album, fieldValue, placeDate)
         }
     }
 


### PR DESCRIPTION
The university requires every diploma thesis to carry a signed statement on the use of AI ("Oświadczenie studenta dotyczące wykorzystania AI" / "Statement of student — Use of AI"), so `apply-pjatk-template()` now generates it automatically. It inserts one statement page per entry in `authors`, placed after the abstract and before the table of contents, and renders the official PJATK legal text in a single language driven by the document's `language` (Polish or English, not bilingual). Each page is filled entirely from arguments: the name and album number are split out of the `authors` entries, the field of study comes from the two new `field-of-study` (default "Computer Science") and `field-of-study-pl` (default "Informatyka") arguments, and the city and localised date ("24 czerwca 2026 r." / "24 June 2026") are inserted automatically, leaving the signature line blank for a handwritten signature. The new arguments and behaviour are documented in the README.

![English AI-use statement (Jan Kowalski / s12345)](https://raw.githubusercontent.com/miloszorzechowski/PJAIT-Typst-Thesis-Template/pr-assets/statement-en.png)

![Polish AI-use statement (Jan Kowalski / s12345)](https://raw.githubusercontent.com/miloszorzechowski/PJAIT-Typst-Thesis-Template/pr-assets/statement-pl.png)
